### PR TITLE
Add output formatting options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,17 +61,17 @@ func main() {
 
 	// Start
 	ticker := time.NewTicker(interval)
-	base_string := printString
+	baseString := printString
 	if printName {
-		base_string = kingpin.CommandLine.Name + " " + base_string
+		baseString = kingpin.CommandLine.Name + " " + baseString
 	}
 
 	go func() {
 		for t := range ticker.C {
 			if printTimestamp {
-				io.WriteString(os.Stdout, fmt.Sprintf("%s %s", base_string, t.Format(time.RFC1123)))
+				io.WriteString(os.Stdout, fmt.Sprintf("%s %s", baseString, t.Format(time.RFC1123)))
 			} else {
-				io.WriteString(os.Stdout, base_string)
+				io.WriteString(os.Stdout, baseString)
 			}
 
 			if printNewline {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -14,16 +16,24 @@ import (
 )
 
 var (
-	version  = "dev"
-	timeout  time.Duration
-	interval time.Duration
-	fullcmd  []string
+	version        = "dev"
+	timeout        time.Duration
+	interval       time.Duration
+	printName      bool
+	printString    string
+	printTimestamp bool
+	printNewline   bool
+	fullcmd        []string
 )
 
 func main() {
 	// Parse command line
 	kingpin.Flag("timeout", "Timeout for this command.").Default("20m").DurationVar(&timeout)
 	kingpin.Flag("interval", "Interval at which to print keep-alive messages.").Default("1m").DurationVar(&interval)
+	kingpin.Flag("print-name", "Print the name of this tool to identify keep-alive messages.").Default("true").BoolVar(&printName)
+	kingpin.Flag("print-string", "Keep-alive message printed in each interval.").Default("Still running...").StringVar(&printString)
+	kingpin.Flag("print-timestamp", "Print the current timestamp after each keep-alive message.").Default("true").BoolVar(&printTimestamp)
+	kingpin.Flag("print-newline", "Print a newline character after each keep-alive message.").Default("true").BoolVar(&printNewline)
 	kingpin.Arg("command", "Command to execute.").Required().StringsVar(&fullcmd)
 	kingpin.UsageTemplate(kingpin.CompactUsageTemplate).Version(version).Author("CrazyMax")
 	kingpin.CommandLine.Name = "travis-wait-enhanced"
@@ -51,9 +61,22 @@ func main() {
 
 	// Start
 	ticker := time.NewTicker(interval)
+	base_string := printString
+	if printName {
+		base_string = kingpin.CommandLine.Name + " " + base_string
+	}
+
 	go func() {
 		for t := range ticker.C {
-			log.Info().Msgf("Still running at %s...", t.Format(time.RFC1123))
+			if printTimestamp {
+				io.WriteString(os.Stdout, fmt.Sprintf("%s %s", base_string, t.Format(time.RFC1123)))
+			} else {
+				io.WriteString(os.Stdout, base_string)
+			}
+
+			if printNewline {
+				io.WriteString(os.Stdout, "\n")
+			}
 		}
 	}()
 	defer ticker.Stop()


### PR DESCRIPTION
Added a bunch of formatting options.
Using zerolog with was not really going well for this usecase (very hacky to prevent printing newline, etc.), so I just used plain stdout writing in the keep-alive message.

Seems to work fine for our use case.

If you like it, I can add some documentation as well.

Closes #5 